### PR TITLE
Introduce lazy properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Markdown to HTML Page Generator Gradle Plugin
-This Gradle plugin's goal is to provide a way of using [the maven markdown-page-generator-plugin by walokra](https://github.com/walokra/markdown-page-generator-plugin).
+This Gradle plugin's goal is to provide a way of using [the maven markdown-page-generator-plugin by Marko Wallin (walokra)](https://github.com/walokra/markdown-page-generator-plugin).
 
 ![Build Status](https://github.com/monosoul/markdown-page-generator-gradle-plugin/actions/workflows/build.yaml/badge.svg)
 ![GitHub release](https://img.shields.io/github/release/monosoul/markdown-page-generator-gradle-plugin.svg)

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ tasks {
         inputEncoding.set(encoding)
         outputEncoding.set(encoding)
 
-        val sourceDir = File(buildDir, "resources/main/markdown")
-        val outputDir = File(buildDir, "html")
+        val sourceDir = project.layout.buildDirectory.dir("resources/main/markdown")
+        val outputDir = project.layout.buildDirectory.dir("/html/")
 
         inputDirectory.set(sourceDir)
         outputDirectory.set(outputDir)
-        headerHtmlFile.set(File(sourceDir, "header.html"))
-        footerHtmlFile.set(File(sourceDir, "footer.html"))
+        headerHtmlFile.set(sourceDir.file("header.html"))
+        footerHtmlFile.set(sourceDir.file("footer.html"))
         transformRelativeMarkdownLinks.set(true)
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Markdown to HTML Page Generator Gradle Plugin
 This Gradle plugin's goal is to provide a way of using [the maven markdown-page-generator-plugin by Marko Wallin (walokra)](https://github.com/walokra/markdown-page-generator-plugin).
 
-![Build Status](https://github.com/monosoul/markdown-page-generator-gradle-plugin/actions/workflows/build.yaml/badge.svg)
+![Build Status](https://github.com/monosoul/markdown-page-generator-gradle-plugin/actions/workflows/build.yaml/badge.svg?branch=master)
 ![GitHub release](https://img.shields.io/github/release/monosoul/markdown-page-generator-gradle-plugin.svg)
 ![license](https://img.shields.io/github/license/monosoul/markdown-page-generator-gradle-plugin.svg)
  
@@ -10,6 +10,7 @@ This Gradle plugin's goal is to provide a way of using [the maven markdown-page-
 ## Gradle compatibility table
 | Plugin version | Gradle version |
 |:----------------:|:--------------:|
+| 2.3.1.1 | \>= 6.8.3 |
 | 2.3.1.0 | \>= 6.8.3 |
 | 2.3.0.0 | \>= 4.9 |
 | 2.1.0.1 | \>= 4.9 |
@@ -19,7 +20,7 @@ This Gradle plugin's goal is to provide a way of using [the maven markdown-page-
 To apply the plugin simply add it to the plugins block of your build script:
 ```kotlin
 plugins {
-  id("com.github.monosoul.markdown.page.generator") version "2.3.1.0"
+  id("com.github.monosoul.markdown.page.generator") version "2.3.1.1"
 }
 ```
 
@@ -46,7 +47,7 @@ Just Gradle, nothing else is needed.
 Using Kotlin DSL:
 ```kotlin
 plugins {
-  id("com.github.monosoul.markdown.page.generator") version "2.3.1.0"
+  id("com.github.monosoul.markdown.page.generator") version "2.3.1.1"
 }
 
 tasks {
@@ -56,19 +57,19 @@ tasks {
 
         val encoding = "UTF-8"
 
-        recursiveInput = true
-        pegdownExtensions = "TABLES,FENCED_CODE_BLOCKS"
-        inputEncoding = encoding
-        outputEncoding = encoding
+        recursiveInput.set(true)
+        pegdownExtensions.set("TABLES,FENCED_CODE_BLOCKS")
+        inputEncoding.set(encoding)
+        outputEncoding.set(encoding)
 
         val sourceDir = File(buildDir, "resources/main/markdown")
         val outputDir = File(buildDir, "html")
 
-        inputDirectory = sourceDir
-        outputDirectory = outputDir
-        headerHtmlFile = File(sourceDir, "header.html")
-        footerHtmlFile = File(sourceDir, "footer.html")
-        transformRelativeMarkdownLinks = true
+        inputDirectory.set(sourceDir)
+        outputDirectory.set(outputDir)
+        headerHtmlFile.set(File(sourceDir, "header.html"))
+        footerHtmlFile.set(File(sourceDir, "footer.html"))
+        transformRelativeMarkdownLinks.set(true)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ tasks {
         outputEncoding.set(encoding)
 
         val sourceDir = project.layout.buildDirectory.dir("resources/main/markdown")
-        val outputDir = project.layout.buildDirectory.dir("/html/")
+        val outputDir = project.layout.buildDirectory.dir("html")
 
         inputDirectory.set(sourceDir)
         outputDirectory.set(outputDir)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.github.monosoul"
-version = "2.3.1.0"
+version = "2.3.1.1"
 
 plugins {
     `kotlin-dsl`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 
 dependencies {
     implementation("com.ruleoftech:markdown-page-generator-plugin:2.3.1")
+    implementation("org.apache.maven:maven-model-builder:3.6.3")
     testImplementation("org.spockframework:spock-core:2.0-groovy-3.0") {
         exclude("org.codehaus.groovy")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,9 +43,17 @@ pluginBundle {
     (plugins) {
         "mdPageGeneratorPlugin" {
             displayName = "Markdown to HTML Page Generator Gradle Plugin"
-            description =
-                "This plugins wraps the maven markdown-page-generator-plugin by walokra so it can be used in Gradle."
-            tags = listOf("markdown", "html", "header", "footer", "walokra")
+            description = "This plugins wraps the maven markdown-page-generator-plugin by " +
+                    "Marko Wallin (walokra) so it can be used in Gradle."
+            tags = listOf(
+                "markdown",
+                "html",
+                "header",
+                "footer",
+                "walokra",
+                "com.ruleoftech",
+                "markdown-page-generator-plugin"
+            )
             version = project.version as String
 
             website = "https://github.com/monosoul/markdown-page-generator-gradle-plugin"

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/GenerateHtmlTask.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/GenerateHtmlTask.kt
@@ -62,17 +62,17 @@ open class GenerateHtmlTask @Inject constructor(
 
     @InputDirectory
     val inputDirectory: DirectoryProperty = objectFactory.directoryProperty().convention(
-        providerFactory.provider { project.layout.projectDirectory.dir("/src/main/resources/markdown/") }
+        providerFactory.provider { project.layout.projectDirectory.dir("src/main/resources/markdown") }
     )
 
     @OutputDirectory
     val outputDirectory: DirectoryProperty = objectFactory.directoryProperty().convention(
-        project.layout.buildDirectory.dir("/html/")
+        project.layout.buildDirectory.dir("html")
     )
 
     @OutputDirectory
     val filteredOutputDirectory: DirectoryProperty = objectFactory.directoryProperty().convention(
-        project.layout.buildDirectory.dir("/filtered-md/")
+        project.layout.buildDirectory.dir("filtered-md")
     )
 
     @InputFile

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/GenerateHtmlTask.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/GenerateHtmlTask.kt
@@ -20,6 +20,7 @@ import com.ruleoftech.markdown.page.generator.plugin.timestampFormat
 import com.ruleoftech.markdown.page.generator.plugin.transformRelativeMarkdownLinks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -32,7 +33,6 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
-import java.io.File
 import javax.inject.Inject
 
 open class GenerateHtmlTask @Inject constructor(
@@ -66,11 +66,11 @@ open class GenerateHtmlTask @Inject constructor(
 
     @InputFile
     @Optional
-    val headerHtmlFile: Property<File> = objectFactory.property()
+    val headerHtmlFile: RegularFileProperty = objectFactory.fileProperty()
 
     @InputFile
     @Optional
-    val footerHtmlFile: Property<File> = objectFactory.property()
+    val footerHtmlFile: RegularFileProperty = objectFactory.fileProperty()
 
     @Input
     val failIfFilesAreMissing: Property<Boolean> = objectFactory.property<Boolean>().convention(true)
@@ -125,10 +125,10 @@ open class GenerateHtmlTask @Inject constructor(
         pageGenMojo.inputDirectory = inputDirectory.asFile.get().path
         pageGenMojo.outputDirectory = outputDirectory.asFile.get().path
         headerHtmlFile.orNull?.let {
-            pageGenMojo.headerHtmlFile = it.path
+            pageGenMojo.headerHtmlFile = it.asFile.path
         }
         footerHtmlFile.orNull?.let {
-            pageGenMojo.footerHtmlFile = it.path
+            pageGenMojo.footerHtmlFile = it.asFile.path
         }
         pageGenMojo.failIfFilesAreMissing = failIfFilesAreMissing.get()
         pageGenMojo.recursiveInput = recursiveInput.get()

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/GenerateHtmlTask.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/GenerateHtmlTask.kt
@@ -19,15 +19,26 @@ import com.ruleoftech.markdown.page.generator.plugin.setInputFileExtensions
 import com.ruleoftech.markdown.page.generator.plugin.timestampFormat
 import com.ruleoftech.markdown.page.generator.plugin.transformRelativeMarkdownLinks
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.property
 import java.io.File
+import javax.inject.Inject
 
-open class GenerateHtmlTask : DefaultTask() {
+open class GenerateHtmlTask @Inject constructor(
+    objectFactory: ObjectFactory,
+    providerFactory: ProviderFactory
+) : DefaultTask() {
 
     init {
         group = "documentation"
@@ -38,96 +49,102 @@ open class GenerateHtmlTask : DefaultTask() {
 
     @Input
     @Optional
-    var defaultTitle: String? = null
+    val defaultTitle: Property<String> = objectFactory.property()
 
     @Input
-    var alwaysUseDefaultTitle: Boolean = false
+    val alwaysUseDefaultTitle: Property<Boolean> = objectFactory.property<Boolean>().convention(false)
 
     @InputDirectory
-    var inputDirectory: File = File(project.projectDir, "/src/main/resources/markdown/")
+    val inputDirectory: DirectoryProperty = objectFactory.directoryProperty().convention(
+        providerFactory.provider { project.layout.projectDirectory.dir("/src/main/resources/markdown/") }
+    )
 
     @OutputDirectory
-    var outputDirectory: File = File(project.buildDir, "/html/")
+    val outputDirectory: DirectoryProperty = objectFactory.directoryProperty().convention(
+        project.layout.buildDirectory.dir("/html/")
+    )
 
     @InputFile
     @Optional
-    var headerHtmlFile: File? = null
+    val headerHtmlFile: Property<File> = objectFactory.property()
 
     @InputFile
     @Optional
-    var footerHtmlFile: File? = null
+    val footerHtmlFile: Property<File> = objectFactory.property()
 
     @Input
-    var failIfFilesAreMissing: Boolean = true
+    val failIfFilesAreMissing: Property<Boolean> = objectFactory.property<Boolean>().convention(true)
 
     @Input
-    var recursiveInput: Boolean = false
+    val recursiveInput: Property<Boolean> = objectFactory.property<Boolean>().convention(false)
 
     @Input
-    var transformRelativeMarkdownLinks: Boolean = false
+    val transformRelativeMarkdownLinks: Property<Boolean> = objectFactory.property<Boolean>().convention(false)
 
     @Input
-    var inputEncoding: String = defaultEncoding
+    val inputEncoding: Property<String> = objectFactory.property<String>().convention(defaultEncoding)
 
     @Input
-    var outputEncoding: String = defaultEncoding
+    val outputEncoding: Property<String> = objectFactory.property<String>().convention(defaultEncoding)
 
     @Input
     @Optional
-    var parsingTimeoutInMillis: Long? = null
+    val parsingTimeoutInMillis: Property<Long> = objectFactory.property()
 
     @Input
-    var inputFileExtensions: String = "md"
+    val inputFileExtensions: Property<String> = objectFactory.property<String>().convention("md")
 
     @Input
-    var outputFileExtension: String = "html"
+    val outputFileExtension: Property<String> = objectFactory.property<String>().convention("html")
 
     @Input
-    var applyFiltering: Boolean = false
+    val applyFiltering: Property<Boolean> = objectFactory.property<Boolean>().convention(false)
 
     @Input
-    var timestampFormat: String = "yyyy-MM-dd\\'T\\'HH:mm:ss\\'Z\\'"
+    val timestampFormat: Property<String> = objectFactory.property<String>()
+        .convention("yyyy-MM-dd\\'T\\'HH:mm:ss\\'Z\\'")
 
     @Input
-    var attributes: Array<String> = arrayOf()
+    val attributes: ListProperty<String> = objectFactory.listProperty<String>().convention(emptyList())
 
     @Input
-    var pegdownExtensions: String = "TABLES"
+    val pegdownExtensions: Property<String> = objectFactory.property<String>().convention("TABLES")
 
     @Input
-    var flexmarkParserOptions: String = "LISTS_ORDERED_LIST_MANUAL_START"
+    val flexmarkParserOptions: Property<String> = objectFactory.property<String>()
+        .convention("LISTS_ORDERED_LIST_MANUAL_START")
 
     @TaskAction
     fun callMavenPlugin() {
         val pageGenMojo = MdPageGeneratorMojo()
         pageGenMojo.log = LoggerAdapter(logger)
-        defaultTitle?.let {
+        defaultTitle.orNull?.let {
             pageGenMojo.defaultTitle = it
         }
-        pageGenMojo.alwaysUseDefaultTitle = alwaysUseDefaultTitle
-        pageGenMojo.inputDirectory = inputDirectory.path
-        pageGenMojo.outputDirectory = outputDirectory.path
-        headerHtmlFile?.let {
+        pageGenMojo.alwaysUseDefaultTitle = alwaysUseDefaultTitle.get()
+        pageGenMojo.inputDirectory = inputDirectory.asFile.get().path
+        pageGenMojo.outputDirectory = outputDirectory.asFile.get().path
+        headerHtmlFile.orNull?.let {
             pageGenMojo.headerHtmlFile = it.path
         }
-        footerHtmlFile?.let {
+        footerHtmlFile.orNull?.let {
             pageGenMojo.footerHtmlFile = it.path
         }
-        pageGenMojo.failIfFilesAreMissing = failIfFilesAreMissing
-        pageGenMojo.recursiveInput = recursiveInput
-        pageGenMojo.transformRelativeMarkdownLinks = transformRelativeMarkdownLinks
-        pageGenMojo.inputEncoding = inputEncoding
-        pageGenMojo.outputEncoding = outputEncoding
-        parsingTimeoutInMillis?.let {
+        pageGenMojo.failIfFilesAreMissing = failIfFilesAreMissing.get()
+        pageGenMojo.recursiveInput = recursiveInput.get()
+        pageGenMojo.transformRelativeMarkdownLinks = transformRelativeMarkdownLinks.get()
+        pageGenMojo.inputEncoding = inputEncoding.get()
+        pageGenMojo.outputEncoding = outputEncoding.get()
+        parsingTimeoutInMillis.orNull?.let {
             pageGenMojo.parsingTimeoutInMillis = it
         }
-        pageGenMojo.setInputFileExtensions(inputFileExtensions)
-        pageGenMojo.applyFiltering = applyFiltering
-        pageGenMojo.outputFileExtension = outputFileExtension
-        pageGenMojo.timestampFormat = timestampFormat
-        pageGenMojo.attributes = attributes
-        pageGenMojo.pegdownExtensions = pegdownExtensions
-        pageGenMojo.flexmarkParserOptions = flexmarkParserOptions
+        pageGenMojo.setInputFileExtensions(inputFileExtensions.get())
+        pageGenMojo.applyFiltering = applyFiltering.get()
+        pageGenMojo.outputFileExtension = outputFileExtension.get()
+        pageGenMojo.timestampFormat = timestampFormat.get()
+        pageGenMojo.attributes = attributes.get().toTypedArray()
+        pageGenMojo.pegdownExtensions = pegdownExtensions.get()
+        pageGenMojo.flexmarkParserOptions = flexmarkParserOptions.get()
 
         pageGenMojo.execute()
     }

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/MavenLoggerAdapter.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/MavenLoggerAdapter.kt
@@ -1,9 +1,9 @@
-package com.github.monosoul.markdown.page.generator.gradle.plugin
+package com.github.monosoul.markdown.page.generator.gradle.plugin.support
 
 import org.apache.maven.plugin.logging.Log
 import org.gradle.api.logging.Logger
 
-class LoggerAdapter(
+class MavenLoggerAdapter(
     private val logger: Logger
 ) : Log {
     override fun isDebugEnabled() = logger.isDebugEnabled

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/MavenProjectBuilder.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/MavenProjectBuilder.kt
@@ -1,0 +1,10 @@
+package com.github.monosoul.markdown.page.generator.gradle.plugin.support
+
+import org.apache.maven.project.MavenProject
+import org.gradle.api.Task
+
+fun Task.buildMavenProject(): MavenProject = MavenProject().apply {
+    groupId = project.group.toString()
+    artifactId = project.name
+    version = project.version.toString()
+}

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/MavenResourcesFilteringBuilder.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/MavenResourcesFilteringBuilder.kt
@@ -1,0 +1,31 @@
+package com.github.monosoul.markdown.page.generator.gradle.plugin.support
+
+import org.apache.maven.shared.filtering.DefaultMavenFileFilter
+import org.apache.maven.shared.filtering.DefaultMavenReaderFilter
+import org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering
+import org.apache.maven.shared.filtering.buildContext
+import org.apache.maven.shared.filtering.mavenFileFilter
+import org.apache.maven.shared.filtering.readerFilter
+import org.codehaus.plexus.logging.PlexusLoggerAdapter
+import org.codehaus.plexus.logging.setLogger
+import org.gradle.api.Task
+import org.sonatype.plexus.build.incremental.DefaultBuildContext
+
+fun Task.buildMavenResourcesFiltering() = DefaultMavenResourcesFiltering().apply {
+    val plexusLoggerAdapter = PlexusLoggerAdapter(logger)
+    val defaultBuildContext = DefaultBuildContext().apply {
+        setLogger(plexusLoggerAdapter)
+    }
+
+    buildContext = defaultBuildContext
+    mavenFileFilter = DefaultMavenFileFilter().apply {
+        buildContext = defaultBuildContext
+        readerFilter = DefaultMavenReaderFilter().apply {
+            setLogger(plexusLoggerAdapter)
+        }
+        setLogger(plexusLoggerAdapter)
+    }
+    setLogger(plexusLoggerAdapter)
+
+    initialize()
+}

--- a/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/ReflectionAccessor.kt
+++ b/src/main/kotlin/com/github/monosoul/markdown/page/generator/gradle/plugin/support/ReflectionAccessor.kt
@@ -1,0 +1,25 @@
+package com.github.monosoul.markdown.page.generator.gradle.plugin.support
+
+import java.lang.reflect.Field
+import kotlin.reflect.KProperty
+
+object ReflectionAccessor {
+    inline operator fun <reified O : Any, T> getValue(obj: O, property: KProperty<*>): T =
+        obj.reflectiveGet(property.name)
+
+    inline operator fun <reified O : Any, T> setValue(obj: O, property: KProperty<*>, value: T) =
+        obj.reflectiveSet(property.name, value)
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified O : Any, T> O.reflectiveGet(fieldName: String): T = getAccessibleField(fieldName).get(this) as T
+    inline fun <reified O : Any, T> O.reflectiveSet(fieldName: String, value: T): Unit = getAccessibleField(fieldName)
+        .set(this, value)
+
+    inline fun <reified O : Any> O.getAccessibleField(fieldName: String): Field = O::class.java
+        .getDeclaredField(fieldName)
+        .apply {
+            if (!isAccessible) {
+                isAccessible = true
+            }
+        }
+}

--- a/src/main/kotlin/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoExtensions.kt
+++ b/src/main/kotlin/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoExtensions.kt
@@ -1,7 +1,10 @@
 package com.ruleoftech.markdown.page.generator.plugin
 
-import java.lang.reflect.Field
-import kotlin.reflect.KProperty
+import com.github.monosoul.markdown.page.generator.gradle.plugin.support.ReflectionAccessor
+import com.github.monosoul.markdown.page.generator.gradle.plugin.support.ReflectionAccessor.reflectiveSet
+import org.apache.maven.project.MavenProject
+import org.apache.maven.shared.filtering.MavenResourcesFiltering
+import java.io.File
 
 var MdPageGeneratorMojo.defaultTitle: String by ReflectionAccessor
 var MdPageGeneratorMojo.alwaysUseDefaultTitle: Boolean by ReflectionAccessor
@@ -22,22 +25,6 @@ var MdPageGeneratorMojo.timestampFormat: String by ReflectionAccessor
 var MdPageGeneratorMojo.attributes: Array<String> by ReflectionAccessor
 var MdPageGeneratorMojo.pegdownExtensions: String by ReflectionAccessor
 var MdPageGeneratorMojo.flexmarkParserOptions: String by ReflectionAccessor
-
-private object ReflectionAccessor {
-    operator fun <T> getValue(obj: MdPageGeneratorMojo, property: KProperty<*>): T = obj.reflectiveGet(property.name)
-
-    operator fun <T> setValue(obj: MdPageGeneratorMojo, property: KProperty<*>, value: T) =
-        obj.reflectiveSet(property.name, value)
-}
-
-@Suppress("UNCHECKED_CAST")
-private fun <T> MdPageGeneratorMojo.reflectiveGet(fieldName: String): T = getAccessibleField(fieldName).get(this) as T
-private fun <T> MdPageGeneratorMojo.reflectiveSet(fieldName: String, value: T): Unit = getAccessibleField(fieldName)
-    .set(this, value)
-
-private fun MdPageGeneratorMojo.getAccessibleField(fieldName: String): Field = javaClass.getDeclaredField(fieldName)
-    .apply {
-        if (!isAccessible) {
-            isAccessible = true
-        }
-    }
+var MdPageGeneratorMojo.project: MavenProject by ReflectionAccessor
+var MdPageGeneratorMojo.mavenResourcesFiltering: MavenResourcesFiltering by ReflectionAccessor
+var MdPageGeneratorMojo.filteredOutputDirectory: File by ReflectionAccessor

--- a/src/main/kotlin/org/apache/maven/shared/filtering/DefaultMavenFileFilterExtensions.kt
+++ b/src/main/kotlin/org/apache/maven/shared/filtering/DefaultMavenFileFilterExtensions.kt
@@ -1,0 +1,7 @@
+package org.apache.maven.shared.filtering
+
+import com.github.monosoul.markdown.page.generator.gradle.plugin.support.ReflectionAccessor
+import org.sonatype.plexus.build.incremental.BuildContext
+
+var DefaultMavenFileFilter.readerFilter: MavenReaderFilter by ReflectionAccessor
+var DefaultMavenFileFilter.buildContext: BuildContext by ReflectionAccessor

--- a/src/main/kotlin/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringExtensions.kt
+++ b/src/main/kotlin/org/apache/maven/shared/filtering/DefaultMavenResourcesFilteringExtensions.kt
@@ -1,0 +1,7 @@
+package org.apache.maven.shared.filtering
+
+import com.github.monosoul.markdown.page.generator.gradle.plugin.support.ReflectionAccessor
+import org.sonatype.plexus.build.incremental.BuildContext
+
+var DefaultMavenResourcesFiltering.buildContext: BuildContext by ReflectionAccessor
+var DefaultMavenResourcesFiltering.mavenFileFilter: MavenFileFilter by ReflectionAccessor

--- a/src/main/kotlin/org/codehaus/plexus/logging/AbstractLogEnabledExtensions.kt
+++ b/src/main/kotlin/org/codehaus/plexus/logging/AbstractLogEnabledExtensions.kt
@@ -1,0 +1,5 @@
+package org.codehaus.plexus.logging
+
+import com.github.monosoul.markdown.page.generator.gradle.plugin.support.ReflectionAccessor.reflectiveSet
+
+fun AbstractLogEnabled.setLogger(logger: Logger) = reflectiveSet("logger", logger)

--- a/src/main/kotlin/org/codehaus/plexus/logging/PlexusLoggerAdapter.kt
+++ b/src/main/kotlin/org/codehaus/plexus/logging/PlexusLoggerAdapter.kt
@@ -1,0 +1,43 @@
+package org.codehaus.plexus.logging
+
+import org.gradle.api.logging.Logger
+import org.codehaus.plexus.logging.Logger as PlexusLogger
+
+class PlexusLoggerAdapter(
+    private val logger: Logger,
+) : AbstractLogger(logger.threshold, logger.name) {
+
+    override fun debug(message: String?, throwable: Throwable?) {
+        logger.debug(message, throwable)
+    }
+
+    override fun info(message: String?, throwable: Throwable?) {
+        logger.info(message, throwable)
+    }
+
+    override fun warn(message: String?, throwable: Throwable?) {
+        logger.warn(message, throwable)
+    }
+
+    override fun error(message: String?, throwable: Throwable?) {
+        logger.error(message, throwable)
+    }
+
+    override fun fatalError(message: String?, throwable: Throwable?) {
+        logger.error(message, throwable)
+    }
+
+    override fun getChildLogger(name: String?): PlexusLogger = this
+
+    private companion object {
+        val Logger.threshold: Int
+            get() = when {
+                isTraceEnabled -> 0
+                isDebugEnabled -> 0
+                isInfoEnabled -> 1
+                isWarnEnabled -> 2
+                isErrorEnabled -> 4
+                else -> 5
+            }
+    }
+}

--- a/src/test/groovy/com/github/monosoul/markdown/page/generator/gradle/plugin/PluginApplicationSpec.groovy
+++ b/src/test/groovy/com/github/monosoul/markdown/page/generator/gradle/plugin/PluginApplicationSpec.groovy
@@ -38,14 +38,14 @@ class PluginApplicationSpec extends Specification {
             
             tasks {
                 "generateHtml"(GenerateHtmlTask::class) {
-                    pegdownExtensions = \"\"\"
+                    pegdownExtensions.set(\"\"\"
                         TABLES,
                         FENCED_CODE_BLOCKS,
                         STRIKETHROUGH,
                         SMARTYPANTS,
                         SMARTS,
                         AUTOLINKS
-                        \"\"\".trimIndent()
+                        \"\"\".trimIndent())
                 }
             }
             """
@@ -80,13 +80,13 @@ class PluginApplicationSpec extends Specification {
             }
 
 			def task = tasks.getByName('generateHtml')
-			task.pegdownExtensions = \"\"\"\
+			task.pegdownExtensions.set(\"\"\"\
                     TABLES,
                     FENCED_CODE_BLOCKS,
                     STRIKETHROUGH,
                     SMARTYPANTS,
                     SMARTS,
-                    AUTOLINKS\"\"\".stripIndent()
+                    AUTOLINKS\"\"\".stripIndent())
             """
 			copyResources()
 		when:

--- a/src/test/groovy/com/github/monosoul/markdown/page/generator/gradle/plugin/PluginApplicationSpec.groovy
+++ b/src/test/groovy/com/github/monosoul/markdown/page/generator/gradle/plugin/PluginApplicationSpec.groovy
@@ -38,6 +38,10 @@ class PluginApplicationSpec extends Specification {
             
             tasks {
                 "generateHtml"(GenerateHtmlTask::class) {
+                    headerHtmlFile.set(inputDirectory.file("html/header.html"))
+                    footerHtmlFile.set(inputDirectory.file("html/footer.html"))
+                    applyFiltering.set(true)
+                
                     pegdownExtensions.set(\"\"\"
                         TABLES,
                         FENCED_CODE_BLOCKS,
@@ -80,6 +84,10 @@ class PluginApplicationSpec extends Specification {
             }
 
 			def task = tasks.getByName('generateHtml')
+			
+			task.headerHtmlFile.set(task.inputDirectory.file('html/header.html'))
+            task.footerHtmlFile.set(task.inputDirectory.file('html/footer.html'))
+            task.applyFiltering.set(true)
 			task.pegdownExtensions.set(\"\"\"\
                     TABLES,
                     FENCED_CODE_BLOCKS,

--- a/src/test/groovy/com/github/monosoul/markdown/page/generator/gradle/plugin/PluginApplicationSpec.groovy
+++ b/src/test/groovy/com/github/monosoul/markdown/page/generator/gradle/plugin/PluginApplicationSpec.groovy
@@ -74,7 +74,7 @@ class PluginApplicationSpec extends Specification {
 	def "should work with groovy dsl and Gradle #gradleVersion"() {
 		setup:
 			def buildFile = new File(testProjectDir, 'build.gradle')
-		new File(testProjectDir, 'settings.gradle') << "rootProject.name = \"markdownGeneratorTest\""
+			new File(testProjectDir, 'settings.gradle') << "rootProject.name = \"markdownGeneratorTest\""
 			buildFile << """
             import com.github.monosoul.markdown.page.generator.gradle.plugin.GenerateHtmlTask
 

--- a/src/test/resources/html/example.html
+++ b/src/test/resources/html/example.html
@@ -1,4 +1,9 @@
-<h1>h1 Heading 8-)</h1>
+<html>
+    <head>
+        <title></title>
+        <meta name="description" content="The new header" />
+    </head>
+    <body><h1>h1 Heading 8-)</h1>
 <h2>h2 Heading</h2>
 <h3>h3 Heading</h3>
 <h4>h4 Heading</h4>
@@ -94,3 +99,6 @@ line 3 of code
 <p><a href="https://github.com/">link text</a></p>
 <p><a href="https://github.com/monosoul/" title="title text!">link with title</a></p>
 <p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a></p>
+        <p>The new footer</p>
+    </body>
+</html>

--- a/src/test/resources/markdown/example.md
+++ b/src/test/resources/markdown/example.md
@@ -1,3 +1,6 @@
+{headerSubstitution=The new header}
+{footerSubstitution=The new footer}
+
 # h1 Heading 8-)
 ## h2 Heading
 ### h3 Heading

--- a/src/test/resources/markdown/html/footer.html
+++ b/src/test/resources/markdown/html/footer.html
@@ -1,0 +1,3 @@
+        <p>${footerSubstitution}</p>
+    </body>
+</html>

--- a/src/test/resources/markdown/html/header.html
+++ b/src/test/resources/markdown/html/header.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <title></title>
+        <meta name="description" content="${headerSubstitution}" />
+    </head>
+    <body>


### PR DESCRIPTION
This PR:
- Introduces lazy properties to enforce lazy configuration;
- Fixes header/footer placeholder substitution with the values from markdown files (see: https://github.com/walokra/markdown-page-generator-plugin/tree/master/src/test/resources/substitute-project for an example)